### PR TITLE
propagate listening port when starting testrpc

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -12,7 +12,7 @@ if testrpc_running $port; then
   echo "Using existing testrpc instance"
 else
   echo "Starting our own testrpc instance" 
-  eval testrpc "$accounts" -u 0 -u 1 > /dev/null &
+  eval testrpc "$accounts" -u 0 -u 1 -p "$port" > /dev/null &
   testrpc_pid=$!
 fi
 

--- a/scripts/testrpc.sh
+++ b/scripts/testrpc.sh
@@ -9,5 +9,5 @@ if testrpc_running $port; then
   echo "Using existing testrpc instance"
 else
   echo "Starting our own testrpc instance" 
-  eval testrpc "$accounts" -u 0 -u 1  
+  eval testrpc "$accounts" -u 0 -u 1 -p "$port"
 fi


### PR DESCRIPTION
Super small fix: the `./scripts/testrpc.sh` script checks to see if `testrpc` is listenting on `$port`, by default `:8545`, but if it's not listening on that port it does not pass `$port` to `testrpc`. 

Obviously the port needs to be updated both here and in `truffle.js` for those wishing to use a non-standard port.