### PR TITLE
Allow calling of `executeTransaction` only by owners which have confirmed the transaction

### DIFF
--- a/contracts/MultiSigWallet.sol
+++ b/contracts/MultiSigWallet.sol
@@ -1,4 +1,4 @@
-/// This code was taken from: https://github.com/ConsenSys. Please do not change or refactor.
+/// This code was taken from: https://github.com/gnosis/MultiSigWallet
 
 pragma solidity ^0.4.15;
 
@@ -151,7 +151,7 @@ contract MultiSigWallet {
 
     /// @dev Allows to replace an owner with a new owner. Transaction has to be sent by wallet.
     /// @param owner Address of owner to be replaced.
-    /// @param owner Address of new owner.
+    /// @param newOwner Address of new owner.
     function replaceOwner(address owner, address newOwner)
         public
         onlyWallet
@@ -222,6 +222,8 @@ contract MultiSigWallet {
     /// @param transactionId Transaction ID.
     function executeTransaction(uint transactionId)
         public
+        ownerExists(msg.sender)
+        confirmed(transactionId, msg.sender)
         notExecuted(transactionId)
     {
         if (isConfirmed(transactionId)) {

--- a/test/MultiSigWallet.js
+++ b/test/MultiSigWallet.js
@@ -414,7 +414,7 @@ contract('MultiSigWallet', (accounts) => {
 
                         context('confirmed', async () => {
                             beforeEach(async () => {
-                                // Make sure that the final confirmation will triggered a failing transaction, for
+                                // Make sure that the final confirmation will trigger a failing transaction, for
                                 // example by ensuring there won't be enough ETH left.
                                 await wallet.submitTransaction(receiver, initETHBalance, [], {from: sender});
                                 let transactionId2 = await wallet.transactionId();
@@ -431,7 +431,7 @@ contract('MultiSigWallet', (accounts) => {
 
                                 assert.equal(web3.eth.getBalance(wallet.address).toNumber(), 0);
 
-                                // Sending a final confirmation and even try to explicitly trigger execution of the
+                                // Sending a final confirmation and even trying to explicitly trigger execution of the
                                 // transaction shouldn't mark it as executed, as there is explicitly not enough ETH to
                                 // handle it.
                                 await wallet.confirmTransaction(transactionId, {from: spec.owners[confirmations]});
@@ -460,7 +460,7 @@ contract('MultiSigWallet', (accounts) => {
                                 });
                             }
 
-                            it('should be executed in a later time', async () => {
+                            it('should be executed successfully when retrying', async () => {
                                 await wallet.executeTransaction(transactionId, {from: sender});
 
                                 assert.equal(web3.eth.getBalance(wallet.address).toNumber(), 0);


### PR DESCRIPTION
FYI, this should be reviewed here first and later I'll open new PR in the public repo.

This PR is an adaptation of the latest fix to the original MultiSigWallet.sol (https://github.com/gnosis/MultiSigWallet). 

It prevents the case when anyone (including not owners or owner who haven't confirmed the transaction) can force an attempt to execute a failed transaction. For example:

Let's say we have a 2/3 multisig wallet with A, B, and C as its owners.

1. Owner A submits an agreed upon transaction to send 100 ETH to some address.
2. Owner B confirms this transaction. 
3. The multisig wallet has received enough confirmations, it'll try to execute this transaction, but alas - there isn't enough ETH available in the wallet, so the transaction will fail and will be marked as such.
4. A or B realize the mistake and make sure that the multisig wallet have enough ETH and are submitting a new transaction (as they have disregarded the old transaction as failed).

At that moment, anyone could've still called `executeTransaction` with the old `transactionId`, which would've worked this time and might have caused unexpected results (e.g., perhaps it'd have sent the ETH to an old address). In addition  to allowing only owners to explicitly call `executeTransaction`, this fix will also prevent other owners, who haven't confirmed this transaction, from explicitly calling this method, in order to prevent "unaware" owners from accidentally making mistakes.