### PR TITLE
fix VM Exception while processing transaction error when running truffle test

### DIFF
--- a/test/helpers/expectRevert.js
+++ b/test/helpers/expectRevert.js
@@ -4,13 +4,14 @@ export default async (promise) => {
     } catch (error) {
         // TODO: Check jump destination to destinguish between a throw and an actual invalid jump.
         const invalidOpcode = error.message.search('invalid opcode') > -1;
+        const revert = error.message.search('revert') >= 0;
 
         // TODO: When we contract A calls contract B, and B throws, instead of an 'invalid jump', we get an 'out of gas'
         // error. How do we distinguish this from an actual out of gas event? The testrpc log actually show an "invalid
         // jump" event).
         const outOfGas = error.message.search('out of gas') > -1;
 
-        assert(invalidOpcode || outOfGas, `Expected throw, got ${error} instead`);
+        assert(invalidOpcode || outOfGas || revert, `Expected throw, got ${error} instead`);
 
         return;
     }


### PR DESCRIPTION
* this commit is related to https://github.com/kinfoundation/kin-token/issues/15,
* add check extra error msg check for 'revert',
* since test revert() under testrpc, expectRevert.js gets error msg as 'invalid opcode',
* while truffle uses ganache-cli, which gets 'revert' error msg.