### PR TITLE
fix 'const DAY' value in test/VestingTrustee.js

### DIFF
--- a/test/VestingTrustee.js
+++ b/test/VestingTrustee.js
@@ -7,7 +7,7 @@ const VestingTrustee = artifacts.require('../contracts/VestingTrustee.sol');
 contract('VestingTrustee', (accounts) => {
     const MINUTE = 60;
     const HOUR = 60 * MINUTE;
-    const DAY = 24 * 60;
+    const DAY = 24 * HOUR;
     const MONTH = 30 * DAY;
     const YEAR = 12 * MONTH;
 


### PR DESCRIPTION
fixes #18 

- add missing '* 60' to value calcuation.
- note the tests have passed until now because the vesting is calculated in real time as well